### PR TITLE
fix: removed unneded save output condition

### DIFF
--- a/rms-facade/get_configurations.tf
+++ b/rms-facade/get_configurations.tf
@@ -2,7 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 data "oci_objectstorage_namespace" "this" {
-  count = (var.save_output && lower(var.configuration_source) == "ocibucket") || lower(var.url_dependency_source) == "ocibucket" ? 1 : 0
+  count = (lower(var.configuration_source) == "ocibucket") || lower(var.url_dependency_source) == "ocibucket" ? 1 : 0
   compartment_id = var.tenancy_ocid
 }
 


### PR DESCRIPTION
Proposed fix implemented.

Tested OK from an existing stack unchecking the "Save Output?" checkbox.

To be merged in next release branch 2.0.5.