### PR TITLE
fix: Compartment creation with defined_tags fails due to tag propagation delay (#67)

### DIFF
--- a/governance.tf
+++ b/governance.tf
@@ -17,3 +17,12 @@ module "oci_lz_tags" {
   compartments_dependency = local.ext_dep_compartments_map
   #compartments_dependency = local.compartments_dependency
 }
+
+resource "time_sleep" "tag_propagation" {
+  count = var.tags_configuration != null ? 1 : 0
+
+  # Tags are cross-region resources, so allow time for their creation to complete before compartments that use them are created.
+  create_duration = "10s"
+
+  depends_on = [module.oci_lz_tags]
+}

--- a/iam.tf
+++ b/iam.tf
@@ -9,6 +9,9 @@ module "oci_lz_compartments" {
   compartments_configuration = var.compartments_configuration
   compartments_dependency    = local.ext_dep_compartments_map
   tags_dependency            = local.tags_dependency
+
+  # Wait for newly created OCI tags before creating compartments that use defined_tags.
+  depends_on                 = [time_sleep.tag_propagation]
 }
 
 module "oci_lz_groups" {


### PR DESCRIPTION
- Add a 10-second delay after tag creation to prevent defined_tags errors during compartment creation.

Signed-off-by: DongHee Lee [inurisis@naver.com](mailto:inurisis@naver.com)